### PR TITLE
SWEEPR-18973: Add utilities for oEmbed urls

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,28 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+// NOTE: We haven't had any specific requests yet for which oEmbed providers to support
+// (the mainstream ones). The full list of supported providers can be found
+// in the official oEmbed providers JSON at https://oembed.com/providers.json.
+// We can pick and add whichever ones we want to enable here.
+var OEMBED_PROVIDERS = [{
+  provider_name: "YouTube",
+  provider_url: "https://www.youtube.com/",
+  endpoints: [{
+    schemes: ["https://*.youtube.com/watch*", "https://*.youtube.com/v/*", "https://youtu.be/*"],
+    url: "https://www.youtube.com/oembed",
+    discovery: true
+  }]
+}, {
+  provider_name: "Vimeo",
+  provider_url: "https://vimeo.com/",
+  endpoints: [{
+    schemes: ["https://vimeo.com/*", "https://vimeo.com/album/*/video/*", "https://vimeo.com/channels/*/*", "https://vimeo.com/groups/*/videos/*", "https://vimeo.com/ondemand/*/*", "https://player.vimeo.com/video/*"],
+    url: "https://vimeo.com/api/oembed.{format}",
+    discovery: true
+  }]
+}];
+var _default = exports["default"] = OEMBED_PROVIDERS;

--- a/lib/getOembedEndpointURL.js
+++ b/lib/getOembedEndpointURL.js
@@ -1,0 +1,68 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var _constants = require("./constants");
+/**
+ * Convert a simple glob pattern (with `*` wildcards) into a RegExp that
+ * matches the entire string.
+ *
+ * @param {string} glob
+ *   A glob pattern, e.g. `"https://*.youtube.com/watch*"`.
+ * @returns {RegExp}
+ *   A RegExp anchored at start/end, case‑insensitive, e.g.:
+ *     globToRegExp('foo*.js') → /^foo[^/]*\.js$/i
+ *
+ * @example
+ * const r = globToRegExp('https://*.youtube.com/watch*');
+ * r.test('https://www.youtube.com/watch?v=abc'); // → true
+ * r.test('https://youtu.be/abc');                // → false
+ */
+var globToRegExp = function globToRegExp(glob) {
+  return new RegExp("^".concat(glob.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, "[^/]*"), "$"), "i");
+};
+
+/**
+ * Returns true if `url` matches at least one glob in `schemes`.
+ */
+var doesURLMatch = function doesURLMatch(url, schemes) {
+  return schemes.some(function (scheme) {
+    return globToRegExp(scheme).test(url);
+  });
+};
+
+/**
+ * Normalizes an oEmbed base URL:
+ * strips any trailing slash
+ * swaps `{format}` - `json`
+ */
+var normalizeUrl = function normalizeUrl() {
+  var url = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "";
+  return url.replace(/\/+$/, "").replace(/\{format\}/gi, "json");
+};
+
+/**
+ * Finds the first endpoint whose schemes include this URL.
+ *
+ * @param {string} url - The media URL to match against provider schemes.
+ * @param {Array<Object>} providers - Array of oEmbed provider definitions.
+ * @returns {string | undefined }
+ *
+ * @example
+ * console.log(getEndpoint('https://www.youtube.com/watch?v=dQw4w9WgXcQ')); // 'https://www.youtube.com/oembed'
+ */
+var getOembedEndpointURL = function getOembedEndpointURL(url) {
+  var providers = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _constants.OEMBED_PROVIDERS;
+  var endpointURL;
+  providers.forEach(function (provider) {
+    provider.endpoints.forEach(function (endpoint) {
+      if (!endpointURL && doesURLMatch(url, endpoint.schemes)) {
+        endpointURL = endpoint.url;
+      }
+    });
+  });
+  return normalizeUrl(endpointURL);
+};
+var _default = exports["default"] = getOembedEndpointURL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui-utils",
-  "version": "2.4.6",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ui-utils",
-      "version": "2.4.6",
+      "version": "2.5.0",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.27.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-utils",
-  "version": "2.4.6",
+  "version": "2.5.0",
   "description": "Utility library shared across React platforms",
   "main": "lib/index.js",
   "peerDependencies": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,41 @@
+// NOTE: We haven't had any specific requests yet for which oEmbed providers to support
+// (the mainstream ones). The full list of supported providers can be found
+// in the official oEmbed providers JSON at https://oembed.com/providers.json.
+// We can pick and add whichever ones we want to enable here.
+const OEMBED_PROVIDERS = [
+  {
+    provider_name: "YouTube",
+    provider_url: "https://www.youtube.com/",
+    endpoints: [
+      {
+        schemes: [
+          "https://*.youtube.com/watch*",
+          "https://*.youtube.com/v/*",
+          "https://youtu.be/*",
+        ],
+        url: "https://www.youtube.com/oembed",
+        discovery: true,
+      },
+    ],
+  },
+  {
+    provider_name: "Vimeo",
+    provider_url: "https://vimeo.com/",
+    endpoints: [
+      {
+        schemes: [
+          "https://vimeo.com/*",
+          "https://vimeo.com/album/*/video/*",
+          "https://vimeo.com/channels/*/*",
+          "https://vimeo.com/groups/*/videos/*",
+          "https://vimeo.com/ondemand/*/*",
+          "https://player.vimeo.com/video/*",
+        ],
+        url: "https://vimeo.com/api/oembed.{format}",
+        discovery: true,
+      },
+    ],
+  },
+];
+
+export default OEMBED_PROVIDERS;

--- a/src/getOembedEndpointURL.js
+++ b/src/getOembedEndpointURL.js
@@ -1,0 +1,62 @@
+import { OEMBED_PROVIDERS } from "./constants";
+
+/**
+ * Convert a simple glob pattern (with `*` wildcards) into a RegExp that
+ * matches the entire string.
+ *
+ * @param {string} glob
+ *   A glob pattern, e.g. `"https://*.youtube.com/watch*"`.
+ * @returns {RegExp}
+ *   A RegExp anchored at start/end, case‑insensitive, e.g.:
+ *     globToRegExp('foo*.js') → /^foo[^/]*\.js$/i
+ *
+ * @example
+ * const r = globToRegExp('https://*.youtube.com/watch*');
+ * r.test('https://www.youtube.com/watch?v=abc'); // → true
+ * r.test('https://youtu.be/abc');                // → false
+ */
+const globToRegExp = (glob) =>
+  new RegExp(
+    `^${glob.replace(/[-/\\^$+?.()|[\]{}]/g, "\\$&").replace(/\*/g, "[^/]*")}$`,
+    "i"
+  );
+
+/**
+ * Returns true if `url` matches at least one glob in `schemes`.
+ */
+const doesURLMatch = (url, schemes) =>
+  schemes.some((scheme) => globToRegExp(scheme).test(url));
+
+/**
+ * Normalizes an oEmbed base URL:
+ * strips any trailing slash
+ * swaps `{format}` - `json`
+ */
+const normalizeUrl = (url = "") =>
+  url.replace(/\/+$/, "").replace(/\{format\}/gi, "json");
+
+/**
+ * Finds the first endpoint whose schemes include this URL.
+ *
+ * @param {string} url - The media URL to match against provider schemes.
+ * @param {Array<Object>} providers - Array of oEmbed provider definitions.
+ * @returns {string | undefined }
+ *
+ * @example
+ * console.log(getEndpoint('https://www.youtube.com/watch?v=dQw4w9WgXcQ')); // 'https://www.youtube.com/oembed'
+ */
+const getOembedEndpointURL = (url, providers = OEMBED_PROVIDERS) => {
+  let endpointURL;
+
+  providers.forEach((provider) => {
+    provider.endpoints.forEach((endpoint) => {
+      if (!endpointURL && doesURLMatch(url, endpoint.schemes)) {
+        endpointURL = endpoint.url;
+      }
+    });
+  });
+
+  return normalizeUrl(endpointURL);
+};
+
+export default getOembedEndpointURL;

--- a/test/oEmbed.spec.js
+++ b/test/oEmbed.spec.js
@@ -1,0 +1,38 @@
+import sinon from "sinon";
+import { expect } from "chai";
+
+import { getEndpointURL } from "../src/oEmbed";
+
+describe("getEndpointURL", () => {
+  it("should return the YouTube oEmbed URL for a valid YouTube link", () => {
+    expect(getEndpointURL("https://www.youtube.com/watch?v=abc123")).to.equal(
+      "https://www.youtube.com/oembed"
+    );
+  });
+
+  it("should return the Vimeo oEmbed URL for a valid Vimeo link", () => {
+    expect(getEndpointURL("https://vimeo.com/123456")).to.equal(
+      "https://vimeo.com/api/oembed.json"
+    );
+  });
+
+  it("should return an empty string for an unknown URL", () => {
+    expect(getEndpointURL("https://unknown.com/video")).to.equal("");
+  });
+
+  it("should return an empty string for a missing URL", () => {
+    expect(getEndpointURL()).to.equal("");
+  });
+
+  it("should support short YouTube links", () => {
+    expect(getEndpointURL("https://youtu.be/abc123")).to.equal(
+      "https://www.youtube.com/oembed"
+    );
+  });
+
+  it("should support Vimeo player links", () => {
+    expect(getEndpointURL("https://player.vimeo.com/video/123456")).to.equal(
+      "https://vimeo.com/api/oembed.json"
+    );
+  });
+});


### PR DESCRIPTION
#### Description

Considering that we need similar utilities for both projects (admin and support), I've moved some of the things in the `ui-utils`.  I was expecting to see them in this repository from the ground up, but they can be introduced slowly in the `ui-admin` when possible.

There are slight changes to these, so whoever uses them in the `ui-admin` should be aware of that.

Ticket: [SWEEPR-18973](https://rosebud-iot.atlassian.net/browse/SWEEPR-18973)


[SWEEPR-18973]: https://rosebud-iot.atlassian.net/browse/SWEEPR-18973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ